### PR TITLE
Add docs diagram for circular buffer mechanism

### DIFF
--- a/docs/design/batching.md
+++ b/docs/design/batching.md
@@ -3,7 +3,7 @@
 ```mermaid
 flowchart TD
     A[Client Sends Inference Requests] --> B[HTTP/gRPC API Layer]
-    B --> C[Request Queue]
+    B --> C[Model Manager]
 
     subgraph "Dynamic Batching Scheduler"
         C --> D{Batch Window Open?}
@@ -19,4 +19,4 @@ flowchart TD
     G --> I[Model Execution on GPU/CPU]
     I --> J[Return Batched Results]
     J --> K[Client Receives Response]
-    ``
+```

--- a/docs/design/circular-buffer.md
+++ b/docs/design/circular-buffer.md
@@ -1,0 +1,16 @@
+## Circular Buffer.
+
+```mermaid
+flowchart TD
+    A[Boot Server] --> B
+    B[HTTP/gRPC Layer] --> C
+    C[Load defined models] --> D[Model Manager
+    modelID, CircularBuffer]
+    subgraph "Buffering"
+        D --> E{Inference Request received?}
+        E -- Yes --> F[Add Inference Request to CircularBuffer]
+        E -- No --> E
+        F --> D
+    end
+    G[Model Batching] -- listens to --> D
+```


### PR DESCRIPTION
This diagram explains usage of Circular Buffer for saving passed model IDs, as well as CircularBuffers for respective ones. 